### PR TITLE
Symtensor refactor

### DIFF
--- a/src/BasicStuff.jl
+++ b/src/BasicStuff.jl
@@ -27,7 +27,7 @@ export ht, gt, h, g, H
 
 # Tensors
 ht(p, q) = sym_tensor("h", p, q)
-gt(p, q, r, s) = sym_tensor("g", p, q, r, s)
+gt(p, q, r, s) = psym_tensor("g", p, q, r, s)
 
 # Operators
 h = summation(ht(p, q) * E(p, q), [p, q])

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -50,3 +50,4 @@ end
 include("tensors/RealTensor.jl")
 include("tensors/SymTensor.jl")
 include("tensors/PSymTensor.jl")
+include("tensors/CCAmpTensor.jl")

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -49,3 +49,4 @@ end
 
 include("tensors/RealTensor.jl")
 include("tensors/SymTensor.jl")
+include("tensors/PSymTensor.jl")

--- a/src/tensors/CCAmpTensor.jl
+++ b/src/tensors/CCAmpTensor.jl
@@ -1,0 +1,63 @@
+# CC amplitude tensor printed as t_ijkl^abcd and appropriate latex code
+# wrapper around PSymTensor, so implements particle exchange symmetry by default
+# cc_amp_tensor("t", a, i, b, j) -> t_ij^ab
+export cc_amp_tensor
+
+struct CCAmpTensor <: Tensor
+    inner::PSymTensor
+
+    function CCAmpTensor(symbol::String, indices::Vector{MOIndex})
+        new(PSymTensor(symbol, indices))
+    end
+end
+
+get_symbol(t::CCAmpTensor) = t.inner.symbol
+get_indices(t::CCAmpTensor) = t.inner.indices
+Base.adjoint(t::CCAmpTensor) = t
+
+function exchange_index(t::CCAmpTensor, i::Int, ind::MOIndex)
+    indices = copy(t.inner.indices)
+    indices[i] = ind
+    CCAmpTensor(t.symbol, indices)
+end
+
+function exchange_index(t::CCAmpTensor, from::MOIndex, to::MOIndex)
+    indices = copy(t.inner.indices)
+    is = findall(x -> x == from, indices)
+    for i in is
+        indices[i] = to
+    end
+    CCAmpTensor(t.symbol, indices)
+end
+
+cc_amp_tensor(symbol, indices...) =
+    CompositeTerm(CCAmpTensor(symbol, collect(indices)))
+
+function Base.show(io::IO, t::CCAmpTensor)
+    print(io, get_symbol(t), '_')
+    inds = get_indices(t)
+    for ind in inds[2:2:end]
+        print(io, ind)
+    end
+    print(io, '^')
+    for ind in inds[1:2:end]
+        print(io, ind)
+    end
+end
+
+function printlatex(io::IO, t::CCAmpTensor, color)
+    print(io, get_symbol(t), "_{")
+    inds = get_indices(t)
+    printlatex(io, inds[2], color)
+    for i in inds[4:2:end]
+        print(io, ' ')
+        printlatex(io, i, color)
+    end
+    print(io, "}^{")
+    printlatex(io, inds[1], color)
+    for i in inds[3:2:end]
+        print(io, ' ')
+        printlatex(io, i, color)
+    end
+    print(io, '}')
+end

--- a/src/tensors/CCAmpTensor.jl
+++ b/src/tensors/CCAmpTensor.jl
@@ -18,7 +18,7 @@ Base.adjoint(t::CCAmpTensor) = t
 function exchange_index(t::CCAmpTensor, i::Int, ind::MOIndex)
     indices = copy(t.inner.indices)
     indices[i] = ind
-    CCAmpTensor(t.symbol, indices)
+    CCAmpTensor(t.inner.symbol, indices)
 end
 
 function exchange_index(t::CCAmpTensor, from::MOIndex, to::MOIndex)
@@ -27,7 +27,7 @@ function exchange_index(t::CCAmpTensor, from::MOIndex, to::MOIndex)
     for i in is
         indices[i] = to
     end
-    CCAmpTensor(t.symbol, indices)
+    CCAmpTensor(t.inner.symbol, indices)
 end
 
 cc_amp_tensor(symbol, indices...) =

--- a/src/tensors/PSymTensor.jl
+++ b/src/tensors/PSymTensor.jl
@@ -1,0 +1,46 @@
+# File for particle exchange symmetry: g(pq)(rs) <-> g(rs)(pq)
+export psym_tensor
+
+struct PSymTensor <: Tensor
+    symbol::String
+    indices::Vector{MOIndex}
+
+    function PSymTensor(symbol::String, indices::Vector{MOIndex})
+        if !iseven(length(indices))
+            throw(
+                "Particle exchange symmetric tensors must have even dimension"
+            )
+        end
+
+        new(
+            symbol,
+            reshape(
+                sortslices(reshape(indices, 2, length(indices) ÷ 2), dims=2),
+                length(indices)
+            )
+        )
+    end
+end
+
+get_symbol(t::PSymTensor) = t.symbol
+get_indices(t::PSymTensor) = t.indices
+Base.adjoint(t::PSymTensor) = t
+
+function exchange_index(t::PSymTensor, i::Int, ind::MOIndex)
+    indices = copy(t.indices)
+    indices[i] = ind
+    PSymTensor(t.symbol, indices)
+end
+
+function exchange_index(t::PSymTensor, from::MOIndex, to::MOIndex)
+    indices = copy(t.indices)
+    is = findall(x -> x == from, indices)
+    for i in is
+        indices[i] = to
+    end
+    PSymTensor(t.symbol, indices)
+end
+
+psym_tensor(symbol, indices...) =
+    CompositeTerm(PSymTensor(symbol, collect(indices)))
+

--- a/src/tensors/SymTensor.jl
+++ b/src/tensors/SymTensor.jl
@@ -1,3 +1,4 @@
+# File for hermitian style symmetry: hpq <-> hqp, gpqrs <-> gqpsr
 export sym_tensor
 
 # Implements symmetric 2-tensor h_pq = h_qp
@@ -15,49 +16,16 @@ struct SymTensor2 <: Tensor
     end
 end
 
+get_symbol(t::T) where {T<:SymTensor2} = t.symbol
 get_indices(t::SymTensor2) = [t.p, t.q]
-
-sym_tensor(symbol, p, q) =
-    CompositeTerm(SymTensor2(symbol, p, q))
-
-# Implements the particle-exchange symmetry, g_pqrs = g_rspq
-struct SymTensor4 <: Tensor
-    symbol::String
-    p::MOIndex
-    q::MOIndex
-    r::MOIndex
-    s::MOIndex
-
-    function SymTensor4(symbol, p, q, r, s)
-        if (p, q) ≤ (r, s)
-            new(symbol, p, q, r, s)
-        else
-            new(symbol, r, s, p, q)
-        end
-    end
-end
-
-get_indices(t::SymTensor4) = [t.p, t.q, t.r, t.s]
-
-get_symbol(t::T) where {T<:Union{SymTensor2,SymTensor4}} = t.symbol
-Base.adjoint(t::T) where {T<:Union{SymTensor2,SymTensor4}} = t
+Base.adjoint(t::T) where {T<:SymTensor2} = t
 
 function exchange_index(t::T, i::Int, ind::MOIndex) where
-{T<:Union{SymTensor2,SymTensor4}}
+{T<:SymTensor2}
     indices = get_indices(t)
     indices[i] = ind
     T(t.symbol, indices...)
 end
 
-function exchange_index(t::T, from::MOIndex, to::MOIndex) where
-{T<:Union{SymTensor2,SymTensor4}}
-    indices = get_indices(t)
-    is = findall(x -> x == from, indices)
-    for i in is
-        indices[i] = to
-    end
-    T(t.symbol, indices...)
-end
-
-sym_tensor(symbol, p, q, r, s) =
-    CompositeTerm(SymTensor4(symbol, p, q, r, s))
+sym_tensor(symbol, p, q) =
+    CompositeTerm(SymTensor2(symbol, p, q))

--- a/src/tensors/SymTensor.jl
+++ b/src/tensors/SymTensor.jl
@@ -23,7 +23,16 @@ Base.adjoint(t::T) where {T<:SymTensor2} = t
 function exchange_index(t::SymTensor2, i::Int, ind::MOIndex)
     indices = get_indices(t)
     indices[i] = ind
-    T(t.symbol, indices...)
+    SymTensor2(t.symbol, indices...)
+end
+
+function exchange_index(t::SymTensor2, from::MOIndex, to::MOIndex)
+    indices = get_indices(t)
+    is = findall(x -> x == from, indices)
+    for i in is
+        indices[i] = to
+    end
+    SymTensor2(t.symbol, indices...)
 end
 
 sym_tensor(symbol, p, q) =

--- a/src/tensors/SymTensor.jl
+++ b/src/tensors/SymTensor.jl
@@ -20,8 +20,7 @@ get_symbol(t::T) where {T<:SymTensor2} = t.symbol
 get_indices(t::SymTensor2) = [t.p, t.q]
 Base.adjoint(t::T) where {T<:SymTensor2} = t
 
-function exchange_index(t::T, i::Int, ind::MOIndex) where
-{T<:SymTensor2}
+function exchange_index(t::SymTensor2, i::Int, ind::MOIndex)
     indices = get_indices(t)
     indices[i] = ind
     T(t.symbol, indices...)


### PR DESCRIPTION
Separated sym_tensor into sym_tensor and psym_tensor:

sym_tensor is for hermitian style symmetries: hpq <-> hqp, gpqrs <-> gqpsr

psym_tensor is for particle exchange style symmetry: g_(pq)(rs) <-> g_(rs)(pq), x_(pq)(rs)(ab) <-> x_(rs)(ab)(pq) <-> ...

Also added cc_amp_tensor which is a wrapper around psym_tensor with the exclusive purpose of nicer printing for t amplidudes:
cc_amp_tensor("t", a, i, c, k, b, j) -> t_ijk^abc